### PR TITLE
Removed sys import

### DIFF
--- a/shuffleLetters.py
+++ b/shuffleLetters.py
@@ -1,6 +1,5 @@
 
 import random           # Used for shuffling letters
-import sys              # Used to exit function (invalid puzzleKey length)
 
 
 """


### PR DESCRIPTION
Originally used for when sys.exit() was in LengthPrereq(), but was changed to return error value.